### PR TITLE
feat: ERC-3156 (extended) wrapper for dYdX

### DIFF
--- a/contracts/aave/AaveERC3156.sol
+++ b/contracts/aave/AaveERC3156.sol
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.7.5;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+
+
+interface FlashBorrowerLike {
+    function onFlashLoan(address user, address token, uint256 value, uint256 fee, bytes calldata) external;
+}
+interface LendingPoolAddressesProviderLike {
+    function getLendingPool() external view returns (address);
+}
+
+interface LendingPoolLike {
+    function flashLoan(
+        address receiverAddress,
+        address[] calldata assets,
+        uint256[] calldata amounts,
+        uint256[] calldata modes,
+        address onBehalfOf,
+        bytes calldata params,
+        uint16 referralCode
+    ) external;
+
+    function getReserveData(address asset) external view returns (ReserveData memory);
+
+    struct ReserveData {
+        //stores the reserve configuration
+        ReserveConfigurationMap configuration;
+        //the liquidity index. Expressed in ray
+        uint128 liquidityIndex;
+        //variable borrow index. Expressed in ray
+        uint128 variableBorrowIndex;
+        //the current supply rate. Expressed in ray
+        uint128 currentLiquidityRate;
+        //the current variable borrow rate. Expressed in ray
+        uint128 currentVariableBorrowRate;
+        //the current stable borrow rate. Expressed in ray
+        uint128 currentStableBorrowRate;
+        uint40 lastUpdateTimestamp;
+        //tokens addresses
+        address aTokenAddress;
+        address stableDebtTokenAddress;
+        address variableDebtTokenAddress;
+        //address of the interest rate strategy
+        address interestRateStrategyAddress;
+        //the id of the reserve. Represents the position in the list of the active reserves
+        uint8 id;
+    }
+
+    struct ReserveConfigurationMap {
+        //bit 0-15: LTV
+        //bit 16-31: Liq. threshold
+        //bit 32-47: Liq. bonus
+        //bit 48-55: Decimals
+        //bit 56: Reserve is active
+        //bit 57: reserve is frozen
+        //bit 58: borrowing is enabled
+        //bit 59: stable rate borrowing enabled
+        //bit 60-63: reserved
+        //bit 64-79: reserve factor
+        uint256 data;
+    }
+}
+
+/**
+ * @author Alberto Cuesta Cañada
+ * @dev ERC-3156 wrapper for Aave flash loans.
+ */
+contract AaveERC3156 {
+    using SafeMath for uint256;
+
+    LendingPoolLike public lendingPool;
+
+    constructor(LendingPoolAddressesProviderLike provider) {
+        lendingPool = LendingPoolLike(provider.getLendingPool());
+    }
+
+    /**
+     * @dev Loan `value` tokens to `receiver`, which needs to return them plus fee to this contract within the same transaction.
+     * @param receiver The contract receiving the tokens, needs to implement the `onFlashLoan(address user, uint256 value, uint256 fee, bytes calldata)` interface.
+     * @param token The loan currency.
+     * @param value The amount of tokens lent.
+     * @param data A data parameter to be passed on to the `receiver` for any custom use.
+     */
+    function flashLoan(address receiver, address token, uint256 value, bytes calldata data) external {
+        address receiverAddress = address(this);
+
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(token);
+
+        uint256[] memory values = new uint256[](1);
+        values[0] = value;
+
+        // 0 = no debt, 1 = stable, 2 = variable
+        uint256[] memory modes = new uint256[](1);
+        modes[0] = 0;
+
+        address onBehalfOf = address(this);
+        bytes memory wrappedData = abi.encode(data, msg.sender, receiver);
+        uint16 referralCode = 0;
+
+        lendingPool.flashLoan(
+            receiverAddress,
+            tokens,
+            values,
+            modes,
+            onBehalfOf,
+            wrappedData,
+            referralCode
+        );
+    }
+
+    /// @dev Aave flash loan callback. It sends the value borrowed to `receiver`, and expects that the value plus the fee will be transferred back.
+    function executeOperation(
+        address[] calldata tokens,
+        uint256[] calldata values,
+        uint256[] calldata fees,
+        address initiator,
+        bytes calldata wrappedData
+    )
+        external returns (bool)
+    {
+        require(msg.sender == address(lendingPool), "Callbacks only allowed from Lending Pool");
+        require(initiator == address(this), "Callbacks only initiated from this contract");
+
+        (bytes memory data, address sender, address receiver) = abi.decode(wrappedData, (bytes, address, address));
+
+        // Send the tokens to the original receiver using the ERC-3156 interface
+        IERC20(tokens[0]).transfer(sender, values[0]);
+        FlashBorrowerLike(receiver).onFlashLoan(sender, tokens[0], values[0], fees[0], data);
+
+        // Approve the LendingPool contract allowance to *pull* the owed amount
+        IERC20(tokens[0]).approve(address(lendingPool), values[0].add(fees[0]));
+
+        return true;
+    }
+
+    /**
+     * @dev The fee to be charged for a given loan.
+     * @param token The loan currency.
+     * @param value The amount of tokens lent.
+     * @return The amount of `token` to be charged for the loan, on top of the returned principal.
+     */
+    function flashFee(address token, uint256 value) external view returns (uint256) {
+        return value.mul(9).div(10000); // lendingPool.FLASHLOAN_PREMIUM_TOTAL()
+    }
+
+    /**
+     * @dev The amount of currency available to be lended.
+     * @param token The loan currency.
+     * @return The amount of `token` that can be borrowed.
+     */
+    function flashSupply(address token) external view returns (uint256) {
+        LendingPoolLike.ReserveData memory reserveData = lendingPool.getReserveData(token);
+        return IERC20(reserveData.aTokenAddress).balanceOf(address(lendingPool));
+    }
+}

--- a/contracts/aave/AaveERC3156.sol
+++ b/contracts/aave/AaveERC3156.sol
@@ -4,66 +4,11 @@ pragma experimental ABIEncoderV2;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
+import "../interfaces/FlashBorrowerLike.sol";
+import "./interfaces/LendingPoolLike.sol";
+import "./interfaces/LendingPoolAddressesProviderLike.sol";
+import "./libraries/AaveDataTypes.sol";
 
-
-interface FlashBorrowerLike {
-    function onFlashLoan(address user, address token, uint256 value, uint256 fee, bytes calldata) external;
-}
-interface LendingPoolAddressesProviderLike {
-    function getLendingPool() external view returns (address);
-}
-
-interface LendingPoolLike {
-    function flashLoan(
-        address receiverAddress,
-        address[] calldata assets,
-        uint256[] calldata amounts,
-        uint256[] calldata modes,
-        address onBehalfOf,
-        bytes calldata params,
-        uint16 referralCode
-    ) external;
-
-    function getReserveData(address asset) external view returns (ReserveData memory);
-
-    struct ReserveData {
-        //stores the reserve configuration
-        ReserveConfigurationMap configuration;
-        //the liquidity index. Expressed in ray
-        uint128 liquidityIndex;
-        //variable borrow index. Expressed in ray
-        uint128 variableBorrowIndex;
-        //the current supply rate. Expressed in ray
-        uint128 currentLiquidityRate;
-        //the current variable borrow rate. Expressed in ray
-        uint128 currentVariableBorrowRate;
-        //the current stable borrow rate. Expressed in ray
-        uint128 currentStableBorrowRate;
-        uint40 lastUpdateTimestamp;
-        //tokens addresses
-        address aTokenAddress;
-        address stableDebtTokenAddress;
-        address variableDebtTokenAddress;
-        //address of the interest rate strategy
-        address interestRateStrategyAddress;
-        //the id of the reserve. Represents the position in the list of the active reserves
-        uint8 id;
-    }
-
-    struct ReserveConfigurationMap {
-        //bit 0-15: LTV
-        //bit 16-31: Liq. threshold
-        //bit 32-47: Liq. bonus
-        //bit 48-55: Decimals
-        //bit 56: Reserve is active
-        //bit 57: reserve is frozen
-        //bit 58: borrowing is enabled
-        //bit 59: stable rate borrowing enabled
-        //bit 60-63: reserved
-        //bit 64-79: reserve factor
-        uint256 data;
-    }
-}
 
 /**
  * @author Alberto Cuesta Cañada
@@ -154,7 +99,7 @@ contract AaveERC3156 {
      * @return The amount of `token` that can be borrowed.
      */
     function flashSupply(address token) external view returns (uint256) {
-        LendingPoolLike.ReserveData memory reserveData = lendingPool.getReserveData(token);
+        AaveDataTypes.ReserveData memory reserveData = lendingPool.getReserveData(token);
         return IERC20(reserveData.aTokenAddress).balanceOf(address(lendingPool));
     }
 }

--- a/contracts/aave/AaveERC3156.sol
+++ b/contracts/aave/AaveERC3156.sol
@@ -19,6 +19,8 @@ contract AaveERC3156 {
 
     LendingPoolLike public lendingPool;
 
+    mapping(address => address) public underlyingToAsset;
+
     constructor(LendingPoolAddressesProviderLike provider) {
         lendingPool = LendingPoolLike(provider.getLendingPool());
     }
@@ -100,6 +102,6 @@ contract AaveERC3156 {
      */
     function flashSupply(address token) external view returns (uint256) {
         AaveDataTypes.ReserveData memory reserveData = lendingPool.getReserveData(token);
-        return IERC20(reserveData.aTokenAddress).balanceOf(address(lendingPool));
+        return IERC20(token).balanceOf(reserveData.aTokenAddress);
     }
 }

--- a/contracts/aave/interfaces/LendingPoolAddressesProviderLike.sol
+++ b/contracts/aave/interfaces/LendingPoolAddressesProviderLike.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.7.5;
+pragma experimental ABIEncoderV2;
+
+interface LendingPoolAddressesProviderLike {
+    function getLendingPool() external view returns (address);
+}

--- a/contracts/aave/interfaces/LendingPoolLike.sol
+++ b/contracts/aave/interfaces/LendingPoolLike.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.7.5;
+pragma experimental ABIEncoderV2;
+
+import "../libraries/AaveDataTypes.sol";
+
+interface LendingPoolLike {
+    function flashLoan(
+        address receiverAddress,
+        address[] calldata assets,
+        uint256[] calldata amounts,
+        uint256[] calldata modes,
+        address onBehalfOf,
+        bytes calldata params,
+        uint16 referralCode
+    ) external;
+
+    function getReserveData(address asset) external view returns (AaveDataTypes.ReserveData memory);
+}

--- a/contracts/aave/libraries/AaveDataTypes.sol
+++ b/contracts/aave/libraries/AaveDataTypes.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.7.5;
+pragma experimental ABIEncoderV2;
+
+library AaveDataTypes {
+
+    struct ReserveData {
+        //stores the reserve configuration
+        ReserveConfigurationMap configuration;
+        //the liquidity index. Expressed in ray
+        uint128 liquidityIndex;
+        //variable borrow index. Expressed in ray
+        uint128 variableBorrowIndex;
+        //the current supply rate. Expressed in ray
+        uint128 currentLiquidityRate;
+        //the current variable borrow rate. Expressed in ray
+        uint128 currentVariableBorrowRate;
+        //the current stable borrow rate. Expressed in ray
+        uint128 currentStableBorrowRate;
+        uint40 lastUpdateTimestamp;
+        //tokens addresses
+        address aTokenAddress;
+        address stableDebtTokenAddress;
+        address variableDebtTokenAddress;
+        //address of the interest rate strategy
+        address interestRateStrategyAddress;
+        //the id of the reserve. Represents the position in the list of the active reserves
+        uint8 id;
+    }
+
+    struct ReserveConfigurationMap {
+        //bit 0-15: LTV
+        //bit 16-31: Liq. threshold
+        //bit 32-47: Liq. bonus
+        //bit 48-55: Decimals
+        //bit 56: Reserve is active
+        //bit 57: reserve is frozen
+        //bit 58: borrowing is enabled
+        //bit 59: stable rate borrowing enabled
+        //bit 60-63: reserved
+        //bit 64-79: reserve factor
+        uint256 data;
+    }
+}

--- a/contracts/aave/mocks/ATokenMock.sol
+++ b/contracts/aave/mocks/ATokenMock.sol
@@ -1,0 +1,18 @@
+pragma solidity 0.7.5;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../../mocks/ERC20Mock.sol";
+
+
+contract ATokenMock is ERC20Mock {
+
+    IERC20 public underlying;
+    constructor (IERC20 underlying_, string memory name, string memory symbol) ERC20Mock(name, symbol) {
+        underlying = underlying_;
+    }
+
+    function transferUnderlyingTo(address to, uint256 amount) external {
+        underlying.transfer(to, amount); // Remember to mint some tokens for ATokenMock first
+    }
+}

--- a/contracts/aave/mocks/LendingPoolAddressesProviderMock.sol
+++ b/contracts/aave/mocks/LendingPoolAddressesProviderMock.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.7.5;
+pragma experimental ABIEncoderV2;
+
+
+contract LendingPoolAddressesProviderMock {
+
+  address public getLendingPool;
+
+  constructor (address lendingPool) {
+    getLendingPool = lendingPool;
+  }
+}

--- a/contracts/aave/mocks/LendingPoolMock.sol
+++ b/contracts/aave/mocks/LendingPoolMock.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 import "../interfaces/LendingPoolAddressesProviderLike.sol";
 import "../libraries/AaveDataTypes.sol";
+import "@nomiclabs/buidler/console.sol";
 
 
 interface FlashLoanReceiverLike {
@@ -109,14 +110,15 @@ contract LendingPoolMock is LendingPoolStorage {
 
   /**
    * @dev Adds a reserve to the reserves list, as an ATokenMock and underlying ERC20Mock pair
-   * @param asset The address of the underlying asset of the reserve
+   * @param aToken The address of the reserve aToken
    **/
-  function addReserve(address asset)
+  function addReserve(address aToken)
     external
   {
+    address asset = ATokenLike(aToken).underlying();
     uint256 reservesCount = _reservesCount;
     _reserves[asset].id = uint8(reservesCount);
-    _reserves[asset].aTokenAddress = ATokenLike(asset).underlying();
+    _reserves[asset].aTokenAddress = aToken;
     _reservesList[reservesCount] = asset;
     _reservesCount = reservesCount + 1;
   }

--- a/contracts/aave/mocks/LendingPoolMock.sol
+++ b/contracts/aave/mocks/LendingPoolMock.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.7.5;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "../interfaces/LendingPoolAddressesProviderLike.sol";
+import "../libraries/AaveDataTypes.sol";
+
+
+interface FlashLoanReceiverLike {
+  function executeOperation(
+    address[] calldata assets,
+    uint256[] calldata amounts,
+    uint256[] calldata premiums,
+    address initiator,
+    bytes calldata params
+  ) external returns (bool);
+}
+
+interface ATokenLike {
+    function underlying() external view returns (address);
+    function transferUnderlyingTo(address, uint256) external;
+}
+
+contract LendingPoolStorage {
+  mapping(address => AaveDataTypes.ReserveData) internal _reserves;
+
+  // the list of the available reserves, structured as a mapping for gas savings reasons
+  mapping(uint256 => address) internal _reservesList;
+
+  uint256 internal _reservesCount;
+}
+
+/**
+ * @title LendingPoolMock contract
+ * @dev Main point of interaction with an Aave protocol's market
+ * - Users can:
+ *   # Execute Flash Loans
+ **/
+contract LendingPoolMock is LendingPoolStorage {
+  using SafeMath for uint256;
+
+  //main configuration parameters
+  uint256 public constant FLASHLOAN_PREMIUM_TOTAL = 9;
+
+  /**
+   * @dev Allows smartcontracts to access the liquidity of the pool within one transaction,
+   * as long as the amount taken plus a fee is returned.
+   * IMPORTANT There are security concerns for developers of flashloan receiver contracts that must be kept into consideration.
+   * For further details please visit https://developers.aave.com
+   * @param receiverAddress The address of the contract receiving the funds, implementing the FlashLoanReceiverLike interface
+   * @param assets The addresses of the assets being flash-borrowed
+   * @param amounts The amounts amounts being flash-borrowed
+   * @param params Variadic packed params to pass to the receiver as extra information
+   **/
+  function flashLoan(
+    address receiverAddress,
+    address[] calldata assets,
+    uint256[] calldata amounts,
+    uint256[] calldata,         // modes
+    address,                    // onBehalfOf
+    bytes calldata params,
+    uint16                      // referralCode
+  ) external {
+    // In this mock we will execute only the flash loan in position 0 of the arrays
+    uint256[] memory premiums = new uint256[](assets.length);
+    premiums[0] = amounts[0].mul(FLASHLOAN_PREMIUM_TOTAL).div(10000);
+
+    address aTokenAddress = _reserves[assets[0]].aTokenAddress;
+    ATokenLike(aTokenAddress).transferUnderlyingTo(receiverAddress, amounts[0]);
+
+    require(
+      FlashLoanReceiverLike(receiverAddress).executeOperation(assets, amounts, premiums, msg.sender, params),
+      "Invalid flash loan return"
+    );
+
+    IERC20(assets[0]).transferFrom(
+        receiverAddress,
+        aTokenAddress,
+        amounts[0].add(premiums[0])
+    );
+  }
+
+  /**
+   * @dev Returns the state and configuration of the reserve
+   * @param asset The address of the underlying asset of the reserve
+   * @return The state of the reserve
+   **/
+  function getReserveData(address asset)
+    external view returns (AaveDataTypes.ReserveData memory)
+  {
+    return _reserves[asset];
+  }
+
+  /**
+   * @dev Returns the list of the initialized reserves
+   **/
+  function getReservesList()
+    external view returns (address[] memory)
+  {
+    address[] memory _activeReserves = new address[](_reservesCount);
+
+    for (uint256 i = 0; i < _reservesCount; i++) {
+      _activeReserves[i] = _reservesList[i];
+    }
+    return _activeReserves;
+  }
+
+  /**
+   * @dev Adds a reserve to the reserves list, as an ATokenMock and underlying ERC20Mock pair
+   * @param asset The address of the underlying asset of the reserve
+   **/
+  function addReserve(address asset)
+    external
+  {
+    uint256 reservesCount = _reservesCount;
+    _reserves[asset].id = uint8(reservesCount);
+    _reserves[asset].aTokenAddress = ATokenLike(asset).underlying();
+    _reservesList[reservesCount] = asset;
+    _reservesCount = reservesCount + 1;
+  }
+}

--- a/contracts/dydx/ICallee.sol
+++ b/contracts/dydx/ICallee.sol
@@ -1,0 +1,46 @@
+/*
+    Copyright 2019 dYdX Trading Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+pragma solidity ^0.7.5;
+pragma experimental ABIEncoderV2;
+
+import "./Types.sol";
+
+/**
+ * @title ICallee
+ * @author dYdX
+ *
+ * Interface that Callees for Solo must implement in order to ingest data.
+ */
+interface ICallee {
+
+    // ============ Public Functions ============
+
+    /**
+     * Allows users to send this contract arbitrary data.
+     *
+     * @param  sender       The msg.sender to Solo
+     * @param  accountInfo  The account from which the data is being sent
+     * @param  data         Arbitrary data given by the sender
+     */
+    function callFunction(
+        address sender,
+        Types.AccountInfo memory accountInfo,
+        bytes memory data
+    )
+    external;
+}

--- a/contracts/dydx/ISoloMargin.sol
+++ b/contracts/dydx/ISoloMargin.sol
@@ -1,0 +1,28 @@
+/*
+
+    Copyright 2020 Kollateral LLC.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+pragma solidity ^0.7.5;
+pragma experimental ABIEncoderV2;
+
+import "./Types.sol";
+
+interface ISoloMargin {
+    function operate(Types.AccountInfo[] memory accounts, Types.ActionArgs[] memory actions) external;
+    function getMarketIsClosing(uint256 marketId) external view returns (bool);
+    function getMarketTokenAddress(uint256 marketId) external view returns (address);
+}

--- a/contracts/dydx/SoloLiquidityProxy.sol
+++ b/contracts/dydx/SoloLiquidityProxy.sol
@@ -1,0 +1,201 @@
+/*
+
+    Copyright 2020 Kollateral LLC.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+pragma solidity ^0.7.5;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "./ISoloMargin.sol";
+import "./Types.sol";
+import "./ICallee.sol";
+
+interface flashBorrowerLike {
+    function onFlashLoan(address user, address token, uint256 value, uint256 fee, bytes calldata data) external;
+}
+
+contract SoloLiquidityProxy is Ownable, ICallee {
+    using SafeMath for uint256;
+
+    uint256 internal NULL_ACCOUNT_ID = 0;
+    uint256 internal NULL_MARKET_ID = 0;
+    Types.AssetAmount internal NULL_AMOUNT = Types.AssetAmount({
+        sign: false,
+        denomination: Types.AssetDenomination.Wei,
+        ref: Types.AssetReference.Delta,
+        value: 0
+    });
+    bytes internal NULL_DATA = "";
+
+    address internal _soloMarginAddress;
+    mapping(address => uint256) internal _tokenAddressToMarketId;
+    mapping(uint256 => address) internal _marketIdToTokenAddress;
+    mapping(address => bool) internal _tokensRegistered;
+
+    constructor (address soloMarginAddress)
+    public {
+        _soloMarginAddress = soloMarginAddress;
+    }
+
+    function registerPool(uint256 marketId) external onlyOwner {
+        address token = ISoloMargin(_soloMarginAddress).getMarketTokenAddress(marketId);
+        require(token != address(0), "SoloLiquidityProxy: cannot register empty market");
+
+        _tokenAddressToMarketId[token] = marketId;
+        _marketIdToTokenAddress[marketId] = token;
+        _tokensRegistered[token] = true;
+        IERC20(token).approve(_soloMarginAddress, uint256(-1));
+    }
+
+    function deregisterPool(uint256 marketId) external onlyOwner {
+        address token = _marketIdToTokenAddress[marketId];
+
+        _tokenAddressToMarketId[token] = 0;
+        _marketIdToTokenAddress[marketId] = address(0);
+        _tokensRegistered[token] = false;
+        IERC20(token).approve(_soloMarginAddress, 0);
+    }
+
+    function flashSupply(address token) external view returns (uint256) {
+        if (isRegistered(token) && !isClosing(token)) {
+            return IERC20(token).balanceOf(_soloMarginAddress);
+        }
+
+        return 0;
+    }
+
+    function flashFee(address token, uint256 amount) public view returns (uint256) {
+        // Add 1 wei for markets 0-1 and 2 wei for markets 2-3
+        return marketIdFromTokenAddress(token) < 2 ? 1 : 2;
+    }
+
+    function flashLoan(address receiver, address token, uint256 amount, bytes memory data) external {
+        ISoloMargin solo = ISoloMargin(_soloMarginAddress);
+        Types.ActionArgs[] memory operations = new Types.ActionArgs[](3);
+        operations[0] = getWithdrawAction(token, amount);
+        operations[1] = getCallAction(abi.encode(data, msg.sender, receiver, token, amount));
+        operations[2] = getDepositAction(token, amount.add(flashFee(token, amount)));
+        Types.AccountInfo[] memory accountInfos = new Types.AccountInfo[](1);
+        accountInfos[0] = getAccountInfo();
+
+        solo.operate(accountInfos, operations);
+    }
+
+    function callFunction(
+        address innerSender,
+        Types.AccountInfo memory accountInfo,
+        bytes memory wrappedData
+    )
+    public override
+    {
+        require(msg.sender == _soloMarginAddress, "SoloLiquidityProxy: callback only from SoloMargin");
+        require(innerSender == address(this), "SoloLiquidityProxy: flashLoan only from this contract");
+
+        (bytes memory data, address sender, address receiver, address token, uint256 amount) = 
+            abi.decode(wrappedData, (bytes, address, address, address, uint256));
+
+        // Transfer to `receiver`
+        require(
+            IERC20(token).transfer(receiver, amount),
+            "SoloLiquidityProxy: transfer to invoker failed");
+
+        flashBorrowerLike(receiver).onFlashLoan(sender, token, amount, flashFee(token, amount), data);
+    }
+
+    function getAccountInfo() internal view returns (Types.AccountInfo memory) {
+        return Types.AccountInfo({
+            owner: address(this),
+            number: 1
+        });
+    }
+
+    function getWithdrawAction(address token, uint256 amount)
+    internal
+    view
+    returns (Types.ActionArgs memory)
+    {
+        return Types.ActionArgs({
+            actionType: Types.ActionType.Withdraw,
+            accountId: 0,
+            amount: Types.AssetAmount({
+                sign: false,
+                denomination: Types.AssetDenomination.Wei,
+                ref: Types.AssetReference.Delta,
+                value: amount
+            }),
+            primaryMarketId: marketIdFromTokenAddress(token),
+            secondaryMarketId: NULL_MARKET_ID,
+            otherAddress: address(this),
+            otherAccountId: NULL_ACCOUNT_ID,
+            data: NULL_DATA
+        });
+    }
+
+    function getDepositAction(address token, uint256 repaymentAmount)
+    internal
+    view
+    returns (Types.ActionArgs memory)
+    {
+        return Types.ActionArgs({
+            actionType: Types.ActionType.Deposit,
+            accountId: 0,
+            amount: Types.AssetAmount({
+                sign: true,
+                denomination: Types.AssetDenomination.Wei,
+                ref: Types.AssetReference.Delta,
+                value: repaymentAmount
+            }),
+            primaryMarketId: marketIdFromTokenAddress(token),
+            secondaryMarketId: NULL_MARKET_ID,
+            otherAddress: address(this),
+            otherAccountId: NULL_ACCOUNT_ID,
+            data: NULL_DATA
+        });
+    }
+
+    function getCallAction(bytes memory data_)
+    internal
+    view
+    returns (Types.ActionArgs memory)
+    {
+        return Types.ActionArgs({
+            actionType: Types.ActionType.Call,
+            accountId: 0,
+            amount: NULL_AMOUNT,
+            primaryMarketId: NULL_MARKET_ID,
+            secondaryMarketId: NULL_MARKET_ID,
+            otherAddress: address(this),
+            otherAccountId: NULL_ACCOUNT_ID,
+            data: data_
+        });
+    }
+
+    function isRegistered(address token) internal view returns (bool) {
+        return _tokensRegistered[token];
+    }
+
+    function marketIdFromTokenAddress(address token) internal view returns (uint256) {
+        return _tokenAddressToMarketId[token];
+    }
+
+    function isClosing(address token) internal view returns (bool) {
+        uint256 marketId = _tokenAddressToMarketId[token];
+        return ISoloMargin(_soloMarginAddress).getMarketIsClosing(marketId);
+    }
+}

--- a/contracts/dydx/Types.sol
+++ b/contracts/dydx/Types.sol
@@ -1,0 +1,72 @@
+/*
+
+    Copyright 2019 dYdX Trading Inc.
+    Copyright 2020 Kollateral LLC.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+pragma solidity ^0.7.5;
+
+library Types {
+    enum ActionType {
+        Deposit,   // supply tokens
+        Withdraw,  // flashLoan tokens
+        Transfer,  // transfer balance between accounts
+        Buy,       // buy an amount of some token (externally)
+        Sell,      // sell an amount of some token (externally)
+        Trade,     // trade tokens against another account
+        Liquidate, // liquidate an undercollateralized or expiring account
+        Vaporize,  // use excess tokens to zero-out a completely negative account
+        Call       // send arbitrary data to an address
+    }
+
+    enum AssetDenomination {
+        Wei, // the amount is denominated in wei
+        Par  // the amount is denominated in par
+    }
+
+    enum AssetReference {
+        Delta, // the amount is given as a delta from the current value
+        Target // the amount is given as an exact number to end up at
+    }
+
+    struct AssetAmount {
+        bool sign; // true if positive
+        AssetDenomination denomination;
+        AssetReference ref;
+        uint256 value;
+    }
+
+    struct Wei {
+        bool sign; // true if positive
+        uint256 value;
+    }
+
+    struct ActionArgs {
+        ActionType actionType;
+        uint256 accountId;
+        AssetAmount amount;
+        uint256 primaryMarketId;
+        uint256 secondaryMarketId;
+        address otherAddress;
+        uint256 otherAccountId;
+        bytes data;
+    }
+
+    struct AccountInfo {
+        address owner;  // The address that owns the account
+        uint256 number; // A nonce that allows a single address to control many accounts
+    }
+}

--- a/contracts/interfaces/FlashBorrowerLike.sol
+++ b/contracts/interfaces/FlashBorrowerLike.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.7.5;
+
+
+interface FlashBorrowerLike {
+    function onFlashLoan(address user, address token, uint256 value, uint256 fee, bytes calldata) external;
+}

--- a/contracts/mocks/FlashBorrower.sol
+++ b/contracts/mocks/FlashBorrower.sol
@@ -4,7 +4,7 @@ import "@nomiclabs/buidler/console.sol";
 
 
 interface FlashLenderLike {
-    function flashLoan(address receiver, uint256 value, bytes calldata) external;
+    function flashLoan(address receiver, address token, uint256 value, bytes calldata) external;
 }
 
 interface ERC20Like {
@@ -28,7 +28,8 @@ contract FlashBorrower {
 
     receive() external payable {}
 
-    function onFlashLoan(address user, uint256 value, uint256 fee, bytes calldata data) external {
+    function onFlashLoan(address user, address token, uint256 value, uint256 fee, bytes calldata data) external {
+        require(token == address(currency), "FlashBorrower: unsupported currency");
         (Action action) = abi.decode(data, (Action)); // Use this to unpack arbitrary data
         flashUser = user;
         flashValue = value;
@@ -47,18 +48,18 @@ contract FlashBorrower {
     function flashBorrow(address lender, uint256 value) public {
         // Use this to pack arbitrary data to `onFlashLoan`
         bytes memory data = abi.encode(Action.NORMAL);
-        FlashLenderLike(lender).flashLoan(address(this), value, data);
+        FlashLenderLike(lender).flashLoan(address(this), address(currency), value, data);
     }
 
     function flashBorrowAndSteal(address lender, uint256 value) public {
         // Use this to pack arbitrary data to `onFlashLoan`
         bytes memory data = abi.encode(Action.STEAL);
-        FlashLenderLike(lender).flashLoan(address(this), value, data);
+        FlashLenderLike(lender).flashLoan(address(this), address(currency), value, data);
     }
 
     function flashBorrowAndReenter(address lender, uint256 value) public {
         // Use this to pack arbitrary data to `onFlashLoan`
         bytes memory data = abi.encode(Action.REENTER);
-        FlashLenderLike(lender).flashLoan(address(this), value, data);
+        FlashLenderLike(lender).flashLoan(address(this), address(currency), value, data);
     }
 }

--- a/contracts/mocks/MockSoloMargin.sol
+++ b/contracts/mocks/MockSoloMargin.sol
@@ -1,0 +1,132 @@
+/*
+
+    Copyright 2020 Kollateral LLC.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+*/
+
+pragma solidity ^0.7.5;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../dydx/ISoloMargin.sol";
+import "../dydx/ICallee.sol";
+
+contract MockSoloMargin is ISoloMargin {
+    using SafeMath for uint256;
+
+    mapping(uint256 => address) internal _markets;
+    bool internal _isClosed;
+
+    uint256 internal _scheduledTokenAmount;
+    uint256 internal _scheduleMarketId;
+    address internal _scheduleAccountAddress;
+    uint256 internal _scheduleAccountNumber;
+
+    constructor(uint256[] memory marketIds, address[] memory tokenAddresses) public {
+        for (uint256 i = 0; i < marketIds.length; i++) {
+            _markets[marketIds[i]] = tokenAddresses[i];
+        }
+        _isClosed = false;
+    }
+
+    function operate(Types.AccountInfo[] memory accounts, Types.ActionArgs[] memory actions) public override {
+        /* data */
+        require(accounts.length == 1, "MockSoloMargin: incorrect accounts length");
+        require(actions.length == 3, "MockSoloMargin: incorrect actions length");
+        _scheduleAccountAddress = accounts[0].owner;
+        _scheduleAccountNumber = accounts[0].number;
+
+        /* withdraw */
+        Types.ActionArgs memory withdraw = actions[0];
+        _scheduledTokenAmount = withdraw.amount.value;
+        _scheduleMarketId = withdraw.primaryMarketId;
+
+        require(withdraw.amount.sign == false, "MockSoloMargin: incorrect withdraw sign");
+        require(withdraw.amount.denomination == Types.AssetDenomination.Wei, "MockSoloMargin: incorrect withdraw denomination");
+        require(withdraw.amount.ref == Types.AssetReference.Delta, "MockSoloMargin: incorrect withdraw reference");
+
+        require(withdraw.actionType == Types.ActionType.Withdraw, "MockSoloMargin: incorrect withdraw action type");
+        require(withdraw.accountId == 0, "MockSoloMargin: must use first account");
+        require(withdraw.otherAddress == msg.sender, "MockSoloMargin: not sending to proxy");
+
+        /* call */
+        Types.ActionArgs memory call = actions[1];
+        require(call.actionType == Types.ActionType.Call, "MockSoloMargin: incorrect call action type");
+        require(call.accountId == 0, "MockSoloMargin: must use first account");
+        require(call.otherAddress == msg.sender, "MockSoloMargin: not invoking proxy");
+
+        /* deposit */
+        Types.ActionArgs memory deposit = actions[2];
+        require(_scheduleMarketId == deposit.primaryMarketId, "MockSoloMargin: marketId mismatch");
+
+        uint256 depositValue = withdraw.amount.value.add(repaymentFee(withdraw.primaryMarketId));
+        require(deposit.amount.value == depositValue, "MockSoloMargin: incorrect deposit value");
+        require(deposit.amount.sign == true, "MockSoloMargin: incorrect deposit sign");
+        require(deposit.amount.denomination == Types.AssetDenomination.Wei, "MockSoloMargin: incorrect deposit denomination");
+        require(deposit.amount.ref == Types.AssetReference.Delta, "MockSoloMargin: incorrect deposit reference");
+
+        require(deposit.actionType == Types.ActionType.Deposit, "MockSoloMargin: incorrect deposit action type");
+        require(deposit.accountId == 0, "MockSoloMargin: must use first account");
+        require(deposit.otherAddress == msg.sender, "MockSoloMargin: not sending to proxy");
+
+        uint256 balanceBefore = balanceOf(withdraw.primaryMarketId);
+
+        transfer(withdraw.primaryMarketId, msg.sender, withdraw.amount.value);
+
+        ICallee(msg.sender).callFunction(msg.sender, Types.AccountInfo({
+            owner: _scheduleAccountAddress,
+            number: _scheduleAccountNumber
+        }), call.data);
+
+        transferFrom(deposit.primaryMarketId, msg.sender, address(this), deposit.amount.value);
+        uint256 balanceAfter = balanceOf(withdraw.primaryMarketId);
+
+        require(balanceAfter == balanceBefore.add(repaymentFee(withdraw.primaryMarketId)), "MockSoloMargin: Incorrect ending balance");
+
+        _scheduledTokenAmount = 0;
+        _scheduleMarketId = 0;
+        _scheduleAccountAddress = address(0);
+        _scheduleAccountNumber = 0;
+    }
+
+    function getMarketIsClosing(uint256 marketId) public view override returns (bool) {
+        return _isClosed;
+    }
+
+    function setClosed(bool closed) external {
+        _isClosed = closed;
+    }
+
+    function getMarketTokenAddress(uint256 marketId) public view override returns (address) {
+        return _markets[marketId];
+    }
+
+    function repaymentFee(uint256 marketId) internal returns (uint256) {
+        return marketId < 2 ? 1 : 2;
+    }
+
+    function transfer(uint256 marketId, address to, uint256 amount) internal returns (bool) {
+        return IERC20(_markets[marketId]).transfer(to, amount);
+    }
+
+    function transferFrom(uint256 marketId, address from, address to, uint256 amount) internal returns (bool) {
+        return IERC20(_markets[marketId]).transferFrom(from, to, amount);
+    }
+
+    function balanceOf(uint256 marketId) internal view returns (uint256) {
+            return IERC20(_markets[marketId]).balanceOf(address(this));
+    }
+}

--- a/test/03_DYDXLender.test.js
+++ b/test/03_DYDXLender.test.js
@@ -1,0 +1,43 @@
+const { BN, expectEvent, expectRevert, balance } = require('@openzeppelin/test-helpers');
+const { expect } = require('chai');
+const { ethers } = require('ethers');
+
+const MockSoloMargin = artifacts.require('MockSoloMargin');
+const SoloLiquidityProxy = artifacts.require('SoloLiquidityProxy');
+const ERC20Mock = artifacts.require('ERC20Mock');
+const FlashBorrower = artifacts.require('FlashBorrower');
+
+/* function encodeExecute(testType, dataAbi, data) {
+  const encodedData = ethers.utils.defaultAbiCoder.encode(dataAbi, data);
+  return ethers.utils.defaultAbiCoder.encode(["uint256", "bytes"], [testType, encodedData]);
+} */
+
+contract('SoloLiquidityProxy', (accounts) => {
+
+  const [ deployer, user1 ] = accounts;
+  const soloBalance = new BN(100000);
+
+  beforeEach(async function () {
+    this.erc20 = await ERC20Mock.new("Test", "TT", { from: deployer });
+    this.borrower = await FlashBorrower.new(this.erc20.address, {from: deployer })
+    this.solo = await MockSoloMargin.new([1], [this.erc20.address], { from: deployer });
+
+    this.proxy = await SoloLiquidityProxy.new(this.solo.address, { from: deployer });
+    await this.proxy.registerPool(1, { from: deployer });
+
+    await this.erc20.mint(this.solo.address, soloBalance.toString(), { from: deployer });
+    await this.erc20.mint(this.borrower.address, 2, { from: deployer });
+  });
+
+  describe('flash loan from dXdY', function () {
+    const underlyingAmount = soloBalance;
+
+    beforeEach(async function () {
+      await this.borrower.flashBorrow(this.proxy.address, underlyingAmount, { from: user1 });
+    });
+
+    it('increments solo balance', async function () {
+      expect(await this.erc20.balanceOf(this.solo.address)).to.be.bignumber.equal(soloBalance.addn(1));
+    });
+  });
+});

--- a/test/04_AaveERC3156.test.js
+++ b/test/04_AaveERC3156.test.js
@@ -1,0 +1,92 @@
+const AToken = artifacts.require('ATokenMock')
+const ERC20Currency = artifacts.require('ERC20Mock')
+const LendingPoolAddressesProvider = artifacts.require('LendingPoolAddressesProviderMock')
+const LendingPool = artifacts.require('LendingPoolMock')
+const AaveERC3156 = artifacts.require('AaveERC3156')
+const FlashBorrower = artifacts.require('FlashBorrower')
+
+const { BN, expectRevert } = require('@openzeppelin/test-helpers')
+require('chai').use(require('chai-as-promised')).should()
+
+const MAX = '115792089237316195423570985008687907853269984665640564039457584007913129639935'
+
+contract('FlashLender', (accounts) => {
+  const [deployer, user1] = accounts
+  let currency1, currency2, aToken1, aToken2, lendingPool, lendingPoolAddressProvider, lender
+  let borrower
+
+  beforeEach(async () => {
+    currency1 = await ERC20Currency.new("Test1", "TST1", { from: deployer })
+    currency2 = await ERC20Currency.new("Test2", "TST2", { from: deployer })
+    aToken1 = await AToken.new(currency1.address, "AToken1", "ATST1", { from: deployer })
+    aToken2 = await AToken.new(currency2.address, "Atoken2", "ATST2", { from: deployer })
+    lendingPool = await LendingPool.new({ from: deployer })
+    await lendingPool.addReserve(aToken1.address, { from: deployer })
+    await lendingPool.addReserve(aToken2.address, { from: deployer })
+    lendingPoolAddressProvider = await LendingPoolAddressesProvider.new(lendingPool.address, { from: deployer })
+    lender = await AaveERC3156.new(lendingPoolAddressProvider.address, { from: deployer })
+
+    borrower = await FlashBorrower.new(currency1.address, { from: deployer })
+
+    await currency1.mint(aToken1.address, 10000, { from: deployer })
+    await currency2.mint(aToken2.address, 9999, { from: deployer })
+  })
+
+  it('should do a simple flash loan', async () => {
+    await borrower.flashBorrow(lender.address, 1, { from: user1 })
+
+    let balanceAfter = await currency1.balanceOf(user1)
+    balanceAfter.toString().should.equal(new BN('0').toString())
+    let flashBalance = await borrower.flashBalance()
+    flashBalance.toString().should.equal(new BN('1').toString())
+    let flashValue = await borrower.flashValue()
+    flashValue.toString().should.equal(new BN('1').toString())
+    let flashUser = await borrower.flashUser()
+    flashUser.toString().should.equal(borrower.address)
+  })
+
+  it('should do a loan that pays fees', async () => {
+    await currency1.mint(borrower.address, 9, { from: user1 })
+    await borrower.flashBorrow(lender.address, 10000, { from: user1 })
+
+    const balanceAfter = await currency1.balanceOf(user1)
+    balanceAfter.toString().should.equal(new BN('0').toString())
+    const flashBalance = await borrower.flashBalance()
+    flashBalance.toString().should.equal(new BN('10009').toString())
+    const flashValue = await borrower.flashValue()
+    flashValue.toString().should.equal(new BN('10000').toString())
+    const flashFee = await borrower.flashFee()
+    flashFee.toString().should.equal(new BN('9').toString())
+    const flashUser = await borrower.flashUser()
+    flashUser.toString().should.equal(borrower.address)
+  })
+
+  /*
+  it('should do a simple flash loan from an EOA', async () => {
+    await lender.flashLoan(borrower.address, currency1.address, 1, '0x0000000000000000000000000000000000000000000000000000000000000000', { from: user1 })
+
+    const balanceAfter = await currency1.balanceOf(user1)
+    balanceAfter.toString().should.equal(new BN('0').toString())
+    const flashBalance = await borrower.flashBalance()
+    flashBalance.toString().should.equal(new BN('1').toString())
+    const flashValue = await borrower.flashValue()
+    flashValue.toString().should.equal(new BN('1').toString())
+    const flashUser = await borrower.flashUser()
+    flashUser.toString().should.equal(user1)
+  })
+
+  it('needs to return funds after a flash loan', async () => {
+    await expectRevert(
+      borrower.flashBorrowAndSteal(lender.address, 1, { from: deployer }),
+      'FlashLender: unpaid loan'
+    )
+  })
+
+  it('should do two nested flash loans', async () => {
+    await borrower.flashBorrowAndReenter(lender.address, 1, { from: deployer })
+
+    const flashBalance = await borrower.flashBalance()
+    flashBalance.toString().should.equal('3')
+  })
+  */
+})


### PR DESCRIPTION
Stripped and modified the SoloLiquidityProxy from Kollateral to conform to ERC-3156 (extended with token addresses).

This means easy flash loans from dYdX.